### PR TITLE
Emissions at firm level

### DIFF
--- a/create_firm_year_emissions.do
+++ b/create_firm_year_emissions.do
@@ -1,0 +1,78 @@
+/*******************************************************************************
+Creates data set at the firm-year level with information on
+1. emissions
+2. BvD id
+3. acitivity and nace ids
+
+TO-DO/Obs:
+1. some firms have 0 emissions for some years. This is probably because in those
+years they were not part of the EUETS, in which case their emissions should be missing,
+and not zero. Need to fix this.
+
+GJ
+*******************************************************************************/
+
+*------------------------------
+* Set-up folders
+*------------------------------
+
+if "`c(username)'"=="chasewilliamson"{
+	global dropbox "/Users/chasewilliamson/Library/CloudStorage/Dropbox/" 
+	
+}
+
+if "`c(username)'"=="jota_"{
+	global dropbox "/Users/jota_/Dropbox/Pesquisa/" 
+	
+}
+
+global raw_data "${dropbox}/carbon_policy_reallocation/data/raw"
+global int_data "${dropbox}/carbon_policy_reallocation/data/intermediate"
+global proc_data "${dropbox}/carbon_policy_reallocation/data/processed"
+
+*------------------------------
+* Read in installation-year info and calculate sum of emissions at the firm level
+*------------------------------
+
+	use "${int_data}/installation_year_emissions.dta", clear
+	
+	g mi_bvdid = missing(bvdid)
+	*tab mi_bvdid // 10% of observations
+	// which is also 10% of installations because it's a balanced panel
+	
+	bysort bvdid year: egen firm_emissions = total(verified) if mi_bvdid == 0
+	
+	*bysort bvdid (activity_id): g act_consistent = activity_id[1] == activity_id[_N] if !missing(bvdid)
+	// not consistent across installations within bvdid
+	
+	*bysort bvdid (nace_id): g nace_consistent = nace_id[1] == nace_id[_N] if !missing(bvdid)
+	// not consistent across installations within bvdid
+	
+	// identify for each bvdid the most polluting installation across all years
+	bysort installation_id: egen installation_emissions = total(verified)
+	bysort bvdid (installation_emissions): egen max_emissions = max(installation_emissions)
+	gen max_installation_id = installation_id if installation_emissions == max_emissions
+	bysort bvdid (max_installation_id): replace max_installation_id = max_installation_id[_N]
+	
+	// create firm-level activity and nace ids
+	bysort bvdid: g bvd_activity = activity_id if installation_id == max_installation_id
+	bysort bvdid (bvd_activity): replace bvd_activity = bvd_activity[1]
+	
+	bysort bvdid: g bvd_nace = nace_id if installation_id == max_installation_id
+	bysort bvdid (bvd_nace): replace bvd_nace = bvd_nace[1]
+	
+	*bysort bvdid (bvd_activity): g act_consistent = bvd_activity[1] == bvd_activity[_N] if !missing(bvdid)
+	// consistent!
+	
+	*bysort bvdid (bvd_nace): g nace_consistent = bvd_nace[1] == bvd_nace[_N] if !missing(bvdid)
+	// consistent!
+	
+	collapse (first) firm_emissions bvd_nace bvd_activity, by(bvdid year)
+	
+	rename bvd_nace nace_id
+	rename bvd_activity activity_id
+	
+	drop if missing(bvdid)
+	
+	save "${int_data}/firm_year_emissions.dta", replace
+	

--- a/create_installation_year_emissions.do
+++ b/create_installation_year_emissions.do
@@ -25,21 +25,65 @@ global int_data "${dropbox}/carbon_policy_reallocation/data/intermediate"
 global proc_data "${dropbox}/carbon_policy_reallocation/data/processed"
 
 *------------------------------
-* Read in account info
+* Read in installation info
 *------------------------------
 
-	tempfile inst
+	import delimited "${raw_data}/EUTL/installation.csv", clear
+	
+	keep if activity_id != 10
+	
+	rename id installation_id
+	
+	keep installation_id nace_id activity_id
+
+
+*------------------------------
+* Read in account (and bvdid) info
+*------------------------------
+
+preserve
+	tempfile account
 	
 	import delimited "${raw_data}/EUTL/account.csv", clear
 
+	keep if accounttype_id == "100-7" | accounttype_id == "120-0"
+	// only OHA, aircraft accounts, or former HA have an installation_id associated with it
+	// and we dont care about aircraft accounts (type 100-9)
+	
 	g mi_instid = missing(installation_id)
-	sum mi_instid // we dont know installation for about 30% of accounts
+	sum mi_instid // we dont know installation for about 6% of those accounts
+	tab accounttype_id if mi_instid == 1 // and they are all "120-0" accounts
 
 	keep if !missing(installation_id)
 	
-	keep installation_id bvdid
+	keep installation_id bvdid accounttype_id // obs uniquely identified by installation_id and accounttype_id
 	
-	save "`inst'"
+	bysort installation_id (bvdid): gen bvdid_consistent = bvdid[1] == bvdid[_N]
+	tab bvdid_consistent // most of obs who share installation_id also share bvdid, but not all
+	
+	drop if bvdid_consistent == 1 & accounttype_id == "120-0" // for those accounts, bvdid is unambiguous
+	
+	bysort installation_id (bvdid): gen bvdid_120 = bvdid[1] == "120-0"
+	// there are no installation_id for which the only account type is a former account (this is reassuring!)
+	
+	drop if accounttype_id == "120-0" // for now, let's focus only on the 100-7.
+	// then, installation_id uniquely identifies accounts
+	
+	drop bvdid_120 bvdid_consistent accounttype_id
+	
+	save "`account'"
+restore
+
+*------------------------------
+* Merge account info to obtain bvdid
+*------------------------------
+
+	merge 1:1 installation_id using "`account'"
+
+	drop if _merge == 1 // this seems to be irrelavant installations
+
+	drop _merge
+
 
 *------------------------------
 * Read in compliance info
@@ -47,14 +91,14 @@ global proc_data "${dropbox}/carbon_policy_reallocation/data/processed"
 
 	import delimited "${raw_data}/EUTL/compliance.csv", clear
 	
-	keep installation_id year verified
+	keep if year <= 2022
 	
 	g mi_em = missing(verified)
 	sum mi_em // info on emissions is missing for ~60% of installation-year obs
 	
 	keep if !missing(verified)
 		
-	duplicates tag installation_id year, generate(duplicate)
+	duplicates tag installation_id year, generate(duplicate) // around 1% of installation-year observations 
 	
 	preserve
 		

--- a/create_installation_year_emissions.do
+++ b/create_installation_year_emissions.do
@@ -2,6 +2,7 @@
 Creates data set at the installation-year level with information on
 1. emissions
 2. BvD id
+3. acitivity and nace ids
 
 TO-DOs/Observations:
 

--- a/create_installation_year_emissions.do
+++ b/create_installation_year_emissions.do
@@ -3,6 +3,15 @@ Creates data set at the installation-year level with information on
 1. emissions
 2. BvD id
 
+TO-DOs/Observations:
+
+1. there are some installations for which bvdid in OHA is not the same as bvdid in FOHA.
+   for all such installations, we are currently using the bvdid as in their OHA
+   
+2. there are some duplicates (in installation_id and year) in compliance data set.
+   for now we are dropping the obs within a duplicate with the LOWEST level of emissions
+   this is arbitrary
+
 GJ
 *******************************************************************************/
 
@@ -36,7 +45,6 @@ global proc_data "${dropbox}/carbon_policy_reallocation/data/processed"
 	
 	keep installation_id nace_id activity_id
 
-
 *------------------------------
 * Read in account (and bvdid) info
 *------------------------------
@@ -51,22 +59,22 @@ preserve
 	// and we dont care about aircraft accounts (type 100-9)
 	
 	g mi_instid = missing(installation_id)
-	sum mi_instid // we dont know installation for about 6% of those accounts
-	tab accounttype_id if mi_instid == 1 // and they are all "120-0" accounts
+	*sum mi_instid // we dont know installation for about 6% of those accounts
+	*tab accounttype_id if mi_instid == 1 // and they are all "120-0" accounts
 
 	keep if !missing(installation_id)
 	
 	keep installation_id bvdid accounttype_id // obs uniquely identified by installation_id and accounttype_id
 	
 	bysort installation_id (bvdid): gen bvdid_consistent = bvdid[1] == bvdid[_N]
-	tab bvdid_consistent // most of obs who share installation_id also share bvdid, but not all
+	*tab bvdid_consistent // most of obs who share installation_id also share bvdid, but not all
 	
 	drop if bvdid_consistent == 1 & accounttype_id == "120-0" // for those accounts, bvdid is unambiguous
 	
 	bysort installation_id (bvdid): gen bvdid_120 = bvdid[1] == "120-0"
 	// there are no installation_id for which the only account type is a former account (this is reassuring!)
 	
-	drop if accounttype_id == "120-0" // for now, let's focus only on the 100-7.
+	drop if accounttype_id == "120-0" // FOR NOW, let's focus only on the 100-7.
 	// then, installation_id uniquely identifies accounts
 	
 	drop bvdid_120 bvdid_consistent accounttype_id
@@ -75,7 +83,7 @@ preserve
 restore
 
 *------------------------------
-* Merge account info to obtain bvdid
+* Merge account info with installation info
 *------------------------------
 
 	merge 1:1 installation_id using "`account'"
@@ -83,7 +91,6 @@ restore
 	drop if _merge == 1 // this seems to be irrelavant installations
 
 	drop _merge
-
 
 *------------------------------
 * Read in compliance info
@@ -93,13 +100,27 @@ restore
 	
 	keep if year <= 2022
 	
-	g mi_em = missing(verified)
-	sum mi_em // info on emissions is missing for ~60% of installation-year obs
+	keep installation_id year verified
 	
-	keep if !missing(verified)
+	bysort installation_id (year): gen starts_2005 = year[1] == 2005
+	drop if starts_2005 == 0 // this is a different type of account that we are not interested on (my guess is that this is country level info)
+	
+	bysort installation_id (year): gen mi_2005 = missing(verified[1])
+	// a lot of those for which emissions are missing in 2005 are installations for which info starts in 2013
+	// an year with big changes in EUETS' regulation
+	
+	duplicates tag installation_id year verified, generate(dup1)
+	*tab dup1 // around 1.9% of installation-year observations;
+	// mostly obs for which verified emissions are missing
+	
+	bysort installation_id year (dup1): drop if dup1 == 1 & _n == 2
+	// drop one obs per duplicate if dup2==1
+	
+	duplicates tag installation_id year, generate(dup2)
+	*tab dup2 // around 0.6% of installation-year observations; they all start 2020 onwards
+	
+	bysort installation_id year (verified): drop if dup1 == 1 & _n == 2
 		
-	duplicates tag installation_id year, generate(duplicate) // around 1% of installation-year observations 
-	
 	preserve
 		
 		keep if duplicate == 1

--- a/create_installation_year_emissions.do
+++ b/create_installation_year_emissions.do
@@ -53,6 +53,14 @@ global proc_data "${dropbox}/carbon_policy_reallocation/data/processed"
 	sum mi_em // info on emissions is missing for ~60% of installation-year obs
 	
 	keep if !missing(verified)
+		
+	duplicates tag installation_id year, generate(duplicate)
+	
+	preserve
+		
+		keep if duplicate == 1
+		
+	restore
 	
 	drop mi_em
 	

--- a/missing_ids.do
+++ b/missing_ids.do
@@ -1,0 +1,59 @@
+/*******************************************************************************
+Investigate where BvD id and installation_id missings come from
+
+GJ
+*******************************************************************************/
+
+*------------------------------
+* Set-up folders
+*------------------------------
+
+if "`c(username)'"=="chasewilliamson"{
+	global dropbox "/Users/chasewilliamson/Library/CloudStorage/Dropbox/" 
+	
+}
+
+if "`c(username)'"=="jota_"{
+	global dropbox "/Users/jota_/Dropbox/Pesquisa/" 
+	
+}
+
+global raw_data "${dropbox}/carbon_policy_reallocation/data/raw"
+global int_data "${dropbox}/carbon_policy_reallocation/data/intermediate"
+global proc_data "${dropbox}/carbon_policy_reallocation/data/processed"
+
+*------------------------------
+* Read in account and keep only installation_id and bvdid
+*------------------------------
+
+import delimited "${raw_data}/EUTL/account.csv", clear
+
+g mi_bvdid = missing(bvdid)
+sum mi_bvdid // About ~25% of accounts couldn't me merged to ORBIS
+
+	// Let's investigate this further: how much of those missing ORBIS ids are from aircrafts?
+	
+	tempfile account
+		
+		g mi_id = missing(installation_id)
+		sum mi_id // About ~30% of accounts do not have installation_id
+		keep if !missing(installation_id)
+		keep installation_id bvdid
+		
+	save "`account'"
+	
+*------------------------------
+* Read in installation and merge
+*------------------------------
+
+	import delimited "${raw_data}/EUTL/installation.csv", clear
+	
+	rename id installation_id
+	keep installation_id isaircraftoperator
+	
+	merge 1:m installation_id using "`account'"
+	
+	g mi_bvdid = missing(bvdid)
+	
+	tab mi_bvdid isaircraft, row // Among installations for which we have account info
+								 // about ~70% of the ones with missing bvdid are NOT aircrafts


### PR DESCRIPTION
Wrote two do-files:
1. create_installation_year_emissions.do creates data set at the installation-year-level with info on emissions, bvdid, activity, and nace codes
2. create_firm_year_emissions.do creates data set at the firm-year-level with into on emissions, activity and nace codes

Also some code to investigate where some missings are coming from, but not sure how relevant this code is/will be. 